### PR TITLE
standardise optional dependencies and build script

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -1,5 +1,11 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
 authors = ["<oss@fastly.com>"]
 description = "A basic Expressly starter kit that demonstrates simple GET, POST, and middleware functionality."
 language = "javascript"
 manifest_version = 2
 name = "Default starter kit for Expressly"
+
+[scripts]
+  build = "npm exec js-compute-runtime ./src/index.js ./bin/main.wasm"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -66,6 +66,21 @@
         "@jakechampion/wizer-win32-x64": "1.6.0"
       }
     },
+    "node_modules/@jakechampion/wizer-darwin-arm64": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jakechampion/wizer-darwin-arm64/-/wizer-darwin-arm64-1.6.0.tgz",
+      "integrity": "sha512-bQdIPdR+Ye0GiNdirVhx0kx14oY2uzwXfh/2dDgteBdcb7mDubzKbdt3ROMyV1UFRVhOtqbthZNk7qLBB6Occg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "wizer-darwin-arm64": "wizer"
+      }
+    },
     "node_modules/@jakechampion/wizer-darwin-x64": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jakechampion/wizer-darwin-x64/-/wizer-darwin-x64-1.6.0.tgz",
@@ -94,6 +109,21 @@
       ],
       "bin": {
         "wizer-linux-x64": "wizer"
+      }
+    },
+    "node_modules/@jakechampion/wizer-win32-x64": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jakechampion/wizer-win32-x64/-/wizer-win32-x64-1.6.0.tgz",
+      "integrity": "sha512-9xzpraJIhLdOnXTC1DjxjyfV52BBlAZTTAlpnE04GxVRvRGZ6wPi/RdACkg3inAfeTP7A/bTq3BJLql/Hansdw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "wizer-win32-x64": "wizer"
       }
     },
     "node_modules/ansi-regex": {


### PR DESCRIPTION
See discussion: https://github.com/fastly/compute-starter-kit-javascript-default/pull/36