### PR TITLE
Update deps and build scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ jobs:
           ${{ runner.os }}-node-
     - run: npm ci
     - name: build
-      run: npm exec js-compute-runtime ./src/index.js ./bin/main.wasm
+      run: npm run build

--- a/fastly.toml
+++ b/fastly.toml
@@ -8,4 +8,4 @@ manifest_version = 2
 name = "Default starter kit for Expressly"
 
 [scripts]
-  build = "npm exec js-compute-runtime ./src/index.js ./bin/main.wasm"
+  build = "npm run build"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,10 +10,112 @@
       "license": "MIT",
       "dependencies": {
         "@fastly/expressly": "^1.2.0",
-        "@fastly/js-compute": "^1.3.2"
+        "@fastly/js-compute": "^1.5.1"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
+    },
+    "node_modules/@bytecodealliance/componentize-js": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.0.1.tgz",
+      "integrity": "sha512-sfQwMMfWZcMJ70cdMm0QnasTTXRM/LGgEzTeBbHPnJE/YQpqMEi4TsjbyGCVV9GLzMC0mRfS8aX8vlkYVhwJcw==",
+      "dependencies": {
+        "@bytecodealliance/jco": "^0.4.0",
+        "@jakechampion/wizer": "^1.6.0"
+      }
+    },
+    "node_modules/@bytecodealliance/jco": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-0.4.2.tgz",
+      "integrity": "sha512-adeezw3wQhuGzEUcc4fZ/Vm9rn7Yp1p+0fbgg7TWfNuVrgbwMN3Me2BVAQqEwfKf3x/jfgbU1D0neFsu83eqYQ==",
+      "dependencies": {
+        "@bytecodealliance/componentize-js": "^0.0.1"
+      },
+      "bin": {
+        "jco": "cli.mjs"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer/-/wizer-1.6.1-beta.4.tgz",
+      "integrity": "sha512-afgV4lyYVMBN/9/yNDgYGTn92D7VrqS0yTZ3WZgDyDTiOWjmSuQimEiX+VzCiYjF9GXsKwzCY1FEOu1pY2Evgw==",
+      "bin": {
+        "wizer": "wizer.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@bytecodealliance/wizer-darwin-arm64": "1.6.1-beta.4",
+        "@bytecodealliance/wizer-darwin-x64": "1.6.1-beta.4",
+        "@bytecodealliance/wizer-linux-x64": "1.6.1-beta.4",
+        "@bytecodealliance/wizer-win32-x64": "1.6.1-beta.4"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-darwin-arm64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-arm64/-/wizer-darwin-arm64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-NyleEH0GKBqS0DCuKceY3a2ZxF/aNzYa68swbKKljSFh6uo/3Cqr/U5/SuTxval6/VwtZ1eEzRPaLbLlUE5r4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "wizer-darwin-arm64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-darwin-x64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-x64/-/wizer-darwin-x64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-2s8HPLrttAyYUJNHQlLVi3rDGlnk9IzEJTbw0DApfpVnCZZ1aTLt6MXTIBeOYo9si5Q4cqyDHT5bAoNZvJTk9A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "wizer-darwin-x64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-linux-x64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-x64/-/wizer-linux-x64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-S+oYRGGveuPLtiI6V7SQpZHhw43asLArC+fGrJRQ3OsHs8aj/IVusRLVYgWfKw1HtZm9iIWrjH9WYO6BWak4eQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "wizer-linux-x64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-win32-x64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-win32-x64/-/wizer-win32-x64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-NxqrLqFnaMyldkN7lBVS+Em23f84/RKrHjBXt9WnZK2RtJjvwoCXr+so6+qfj4f1K9BhIZ8UaBfYwqPvtLOcZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "wizer-win32-x64": "wizer"
       }
     },
     "node_modules/@fastly/expressly": {
@@ -31,13 +133,14 @@
       }
     },
     "node_modules/@fastly/js-compute": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-1.3.2.tgz",
-      "integrity": "sha512-SvWaa2Qf05AKeNejW55/5T3ROd+mO7mRQh/wBNH29OyqJOi4lrC9D3uCWJMjdyyi4jxrL6ux8vWGJglFCBRoyQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-1.5.1.tgz",
+      "integrity": "sha512-PXTZtB4cQziFyOs4KPpZ9ZW6sOOYv2PslXH9HVPDkDCo+G+Q+HcnKKc1giGPGR/NipqVkCugkaNynaVHMCrijw==",
       "dependencies": {
-        "@jakechampion/wizer": "^1.6.0",
+        "@bytecodealliance/jco": "^0.4.1",
+        "@bytecodealliance/wizer": "^1.6.1-beta.4",
         "esbuild": "^0.15.16",
-        "js-component-tools": "0.2.2",
+        "regexpu-core": "^5.3.1",
         "tree-sitter": "^0.20.1",
         "tree-sitter-javascript": "^0.19.0"
       },
@@ -45,8 +148,8 @@
         "js-compute-runtime": "js-compute-runtime-cli.js"
       },
       "engines": {
-        "node": "16 - 18",
-        "npm": "^8"
+        "node": "16 - 19",
+        "npm": "^8 || ^9"
       }
     },
     "node_modules/@jakechampion/wizer": {
@@ -431,12 +534,12 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
-    "node_modules/js-component-tools": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/js-component-tools/-/js-component-tools-0.2.2.tgz",
-      "integrity": "sha512-+DorgW2JyOf3Qja35wtw0VQYkcdo4tkInapJ4xlPJXXW49RhEdNMzX/PoHKC5nS7AhV1VBweA1gmYOIYUOXDLw==",
+    "node_modules/jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
       "bin": {
-        "jsct": "cli.mjs"
+        "jsesc": "bin/jsesc"
       }
     },
     "node_modules/mimic-response": {
@@ -587,6 +690,49 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="
+    },
+    "node_modules/regenerate-unicode-properties": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz",
+      "integrity": "sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==",
+      "dependencies": {
+        "regenerate": "^1.4.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regexpu-core": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.2.tgz",
+      "integrity": "sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==",
+      "dependencies": {
+        "@babel/regjsgen": "^0.8.0",
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.1.0",
+        "regjsparser": "^0.9.1",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regjsparser": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+      "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
+      "dependencies": {
+        "jsesc": "~0.5.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
       }
     },
     "node_modules/safe-buffer": {
@@ -748,6 +894,42 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-value-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-property-aliases-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   },
   "dependencies": {
     "@fastly/expressly": "^1.2.0",
-    "@fastly/js-compute": "^1.3.2"
+    "@fastly/js-compute": "^1.5.1"
+  },
+  "scripts": {
+    "build": "js-compute-runtime ./src/index.js ./bin/main.wasm",
+    "deploy": "fastly compute publish"
   }
 }


### PR DESCRIPTION
PR suggests updates:

* standardize on build scripts: fastly.toml calls `npm run build`, `build` calls `js-compute-runtime`, and `deploy` uses `fastly compute publish`.
* update js-compute library to 1.5.1 