### PR TITLE
Use @fastly/cli in the starter kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,26 @@ This starter is intentionally lightweight, and only requires the [`@fastly/js-co
 
 The starter doesn't require the use of any backends. Once deployed, you will have a Fastly service running on Compute that can generate synthetic responses at the edge.
 
+## Running the application
+
+To create an application using this starter kit, create a new directory for your application and switch to it, and then type the following command:
+
+```shell
+npm create @fastly/compute@latest -- --language=javascript --starter-kit=expressly
+```
+
+To build and run your new application in the local development environment, type the following command:
+
+```shell
+npm run start
+```
+
+To build and deploy your application to your Fastly account, type the following command. The first time you deploy the application, you will be prompted to create a new service in your account.
+
+```shell
+npm run deploy
+```
+
 ## Security issues
 
 Please see our [SECURITY.md](SECURITY.md) for guidance on reporting security-related issues.

--- a/fastly.toml
+++ b/fastly.toml
@@ -8,4 +8,5 @@ manifest_version = 2
 name = "Default starter kit for expressly"
 
 [scripts]
-  build = "npm run build"
+build = "npm run build"
+post_init = "npm install"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
     "@fastly/expressly": "^2.0.0",
     "@fastly/js-compute": "^3.0.0"
   },
+  "devDependencies": {
+    "@fastly/cli": "^10.14.0"
+  },
   "scripts": {
     "build": "js-compute-runtime ./src/index.js ./bin/main.wasm",
+    "start": "fastly compute serve",
     "deploy": "fastly compute publish"
   }
 }


### PR DESCRIPTION
This PR makes changes:

* Changes to **package.json** to enable usage without a global installation of the Fastly CLI:
   * Adds `@fastly/cli` to `devDependencies` so that it's available when using the starter kit, as a tool used to build and run or publish the application.
   * Makes sure that `scripts` contains `start` and `deploy` scripts as applicable.

* Adds instructions to the README describing how to initialize an application using the starter kit, as well as how to run it locally or publish it to a Fastly service, as applicable.

* Adds `post_init` script to run `npm install` if it was not present.